### PR TITLE
Fix ol margin-left

### DIFF
--- a/style.css
+++ b/style.css
@@ -689,7 +689,7 @@ div.talks dd + dt {
 
 cite { font-weight: bold;}
 
-ol ol { margin: 1.5rem;}
+ol { margin-left: 1.5rem;}
 
 #proposed-topics {
   list-style: none;


### PR DESCRIPTION
I'm actually not sure why this is necessary but without it the numbered list on the application-questions page is shifted to the left into the border... at least both on Firefox and Safari.