### PR TITLE
Add a paper for web security docs

### DIFF
--- a/papers/security-docs.md
+++ b/papers/security-docs.md
@@ -17,7 +17,7 @@ Given the survey results, and with the help of subject matter experts, we want t
 
 To achieve this we want to use Divio’s documentation system to make the docs better. It requires four different types of documentation to be created: Tutorials (learning-oriented), How-Tos (problem-oriented), Guides (understanding-oriented), Reference (information-oriented).
 
-Currently, on MDN, web security is documented on the Web/Security page with a few subpages. We would like to bring structure into this documentation area and fill gaps.
+Currently, on MDN, web security is documented on the [Web/Security page](https://developer.mozilla.org/en-US/docs/Web/Security) with a few subpages. We would like to bring structure into this documentation area and fill gaps.
 
 
 ## Resources

--- a/papers/security-docs.md
+++ b/papers/security-docs.md
@@ -1,5 +1,7 @@
 # Documentation for web security education
 
+By [Florian Scholz](#author).
+
 ## Description
 
 The WebDX group ran a short survey on MDN to identify the most challenging security aspects that web devs need to face today. (297 responses)

--- a/papers/security-docs.md
+++ b/papers/security-docs.md
@@ -22,8 +22,8 @@ Currently, on MDN, web security is documented on the Web/Security page with a fe
 
 ## Resources
 
-* [https://developer.mozilla.org/en-US/docs/Web/Security](https://developer.mozilla.org/en-US/docs/Web/Security) 
-* [https://documentation.divio.com/](https://documentation.divio.com/)
+* [MDN Web Docs - Security on the Web](https://developer.mozilla.org/en-US/docs/Web/Security) 
+* [DIVIO - The documentation system](https://documentation.divio.com/)
 
 
 ## Author

--- a/papers/security-docs.md
+++ b/papers/security-docs.md
@@ -1,0 +1,31 @@
+# Documentation for web security education
+
+## Description
+
+The WebDX group ran a short survey on MDN to identify the most challenging security aspects that web devs need to face today. (297 responses)
+
+At least two aspects of this survey suggest that better education is needed:
+
+* "Understanding security threats": 29% said "very challenging" and 40% "somewhat challenging".
+* "Understanding the browser security model": 27% said "very challenging" and 39% said "somewhat challenging"
+
+The Open Web Docs team would like to attend the Secure the Web Forward workshop to collaborate with a group of security experts on writing better documentation for web security on MDN Web Docs.
+
+Given the survey results, and with the help of subject matter experts, we want to produce a content outline to improve the information web developers need to understand web security.
+
+To achieve this we want to use Divio’s documentation system to make the docs better. It requires four different types of documentation to be created: Tutorials (learning-oriented), How-Tos (problem-oriented), Guides (understanding-oriented), Reference (information-oriented).
+
+Currently, on MDN, web security is documented on the Web/Security page with a few subpages. We would like to bring structure into this documentation area and fill gaps.
+
+
+## Resources
+
+* [https://developer.mozilla.org/en-US/docs/Web/Security](https://developer.mozilla.org/en-US/docs/Web/Security) 
+* [https://documentation.divio.com/](https://documentation.divio.com/)
+
+
+## Author
+
+Open Web Docs (OWD) is a non-profit collective funded by corporate and individual donations. More information is available at [https://openwebdocs.org](https://openwebdocs.org).
+
+Florian Scholz is a Technical Writer at Open Web Docs. Email: [florian@openwebdocs.org](mailto:florian@openwebdocs.org).

--- a/papers/security-docs.md
+++ b/papers/security-docs.md
@@ -15,7 +15,7 @@ The Open Web Docs team would like to attend the Secure the Web Forward workshop 
 
 Given the survey results, and with the help of subject matter experts, we want to produce a content outline to improve the information web developers need to understand web security.
 
-To achieve this we want to use Divio’s documentation system to make the docs better. It requires four different types of documentation to be created: Tutorials (learning-oriented), How-Tos (problem-oriented), Guides (understanding-oriented), Reference (information-oriented).
+To achieve this we want to use [Divio](https://documentation.divio.com/)’s documentation system to make the docs better. It requires four different types of documentation to be created: Tutorials (learning-oriented), How-Tos (problem-oriented), Guides (understanding-oriented), Reference (information-oriented).
 
 Currently, on MDN, web security is documented on the [Web/Security page](https://developer.mozilla.org/en-US/docs/Web/Security) with a few subpages. We would like to bring structure into this documentation area and fill gaps.
 

--- a/papers/security-docs.md
+++ b/papers/security-docs.md
@@ -28,6 +28,6 @@ Currently, on MDN, web security is documented on the [Web/Security page](https:/
 
 ## Author
 
-Open Web Docs (OWD) is a non-profit collective funded by corporate and individual donations. More information is available at [https://openwebdocs.org](https://openwebdocs.org).
+Open Web Docs (OWD) is a non-profit collective funded by corporate and individual donations. More information is available on the [Open Web Docs](https://openwebdocs.org) web site.
 
 Florian Scholz is a Technical Writer at Open Web Docs. Email: [florian@openwebdocs.org](mailto:florian@openwebdocs.org).

--- a/papers/security-docs.md
+++ b/papers/security-docs.md
@@ -4,7 +4,7 @@ By [Florian Scholz](#author).
 
 ## Description
 
-The WebDX group ran a short survey on MDN to identify the most challenging security aspects that web devs need to face today. (297 responses)
+The WebDX community group ran a short survey on MDN to [identify the most challenging security aspects that web devs need to face today](https://github.com/web-platform-dx/developer-research/blob/main/mdn-short-surveys/2023-05-15-security-dx/interpretation.md). (297 responses)
 
 At least two aspects of this survey suggest that better education is needed:
 


### PR DESCRIPTION
This is Open Web Docs' paper for the Secure the Web Forward workshop.